### PR TITLE
Update 1.md

### DIFF
--- a/src/de/topic/1.md
+++ b/src/de/topic/1.md
@@ -2,13 +2,13 @@
 ---article_info
 title: Was ist Chrysalis?
 author: [author_1]
-reviews: [skay, Doenermaker, new_reviewer]
+reviews: [skay, Doenermaker, TomMax2407]
 ---
 -->
 
 # Was ist Chrysalis?
 
-Die IOTA Foundation ist auf dem besten Weg, ihr Kernziel eines koordinatorfreien und damit dezentralem IOTA-Mainnet zu verwirklichen. Bei der Grundlagenforschung zum Coordicide und der Umsetzung in GoShimmer wurden erhebliche Fortschritte erzielt. Einige Coordicide-Module wurden bereits dem IOTA-Mainnet hinzugefügt, einschließlich Autopeering und Object-Storage. Bevor der Coordicide abgeschlossen werden kann, soll das IOTA-Mainnet zuvor weiter optimiert und eine unternehmenstaugliche Lösung für das Ökosystem bereitgestellt werden. 
+Die IOTA Foundation ist auf dem besten Weg, ihr Kernziel eines koordinatorfreien und damit dezentralen IOTA-Mainnets zu verwirklichen. In der Grundlagenforschung zum Coordicide und der Umsetzung in GoShimmer wurden erhebliche Fortschritte erzielt. Einige Coordicide-Module wurden bereits dem IOTA-Mainnet hinzugefügt, einschließlich Autopeering und Object-Storage. Bevor der Coordicide abgeschlossen werden kann, soll das IOTA-Mainnet zuvor weiter optimiert und eine unternehmenstaugliche Lösung für das Ökosystem bereitgestellt werden. 
 
 Diese Zwischenaktualisierung läuft unter dem Projektnamen „Chrysalis“. Eine Chrysalis (dt. Puppe) ist "die Form, die eine Raupe annimmt, bevor sie als voll ausgebildete Motte oder als Schmetterling aus ihrem Kokon hervortritt". Im Kontext von IOTA steht Chrysalis für die Transformation des Mainnets in eine ausgereifte Form, um IOTA zur Produktionsreife zu bringen.
 


### PR DESCRIPTION
nur zwei kleine Veränderungen: Zeile 11 benötigt an der korrigierten Stelle den Genitiv + "in" etwas Fortschritte erzielen (gehobener)

Weitere Anmerkung: Zeile 13 für die Erklärung einer Chrysalis wird hier zitiert, ABER die Quellenangabe des Zitats fehlt. Besser: Quelle ergänzen oder nicht als Zitat kennzeichnen. (Falls es aber ein Zitet ist, unbedingt die Quelle angeben). Zusätzlich wäre es sinnvoll, Gänsefüßchen einheitlich zu setzen (am besten in der deutschen Variante), d.h: zu Beginn eines Zitats bzw. eines Fachbegriffs unten, zum Schluss oben. Hier wird dies in zwei aufeinanderfolgenden Sätzen unterschiedlich gehandhabt, siehe „Chrysalis“ und "die Form, die eine (...)"