### PR TITLE
Update 8.md

### DIFF
--- a/src/de/what_is/8.md
+++ b/src/de/what_is/8.md
@@ -2,7 +2,7 @@
 ---article_info
 title: Was ist "New Milestone Selection"?
 author: [author_1]
-reviews: [Doenermaker, reviewer_2]
+reviews: [Doenermaker, CrashOverride]
 ---
 -->
 
@@ -11,7 +11,7 @@ reviews: [Doenermaker, reviewer_2]
 Um das Ziel zu erreichen, möglichst alle Messages so schnell wie möglich durch den Koordinator zu bestätigen, wurde für diesen ein neuer Meilenstein-Auswahlalgorithmus entwickelt.
 Kurz gesagt, wählt der Koordinator die Tips für den Meilstenstein jetzt intelligent aus.
 
-Der Koordinator erzeugt etwa alle 10 Sekunden einen Meilenstein, welcher wie jede andere Message auch mindestens zwei Tips referenzieren sollte (es gibt auch spezielle Fälle in denen nur ein Tip vorhanden ist, dann wird nur einer genommen). Tips sind die Messages im Tangle, die noch nicht von anderen Messages referenziert wurden (Grau im rechten Bereich des Bildes).
+Der Koordinator erzeugt etwa alle 10 Sekunden einen Meilenstein, welcher wie jede andere Message auch mindestens zwei Tips referenzieren sollte. Tips sind die Messages im Tangle, die noch nicht von anderen Messages referenziert wurden (Grau im rechten Bereich des Bildes).
 
 ![image](https://user-images.githubusercontent.com/46689931/120787374-917daf00-c52f-11eb-8355-7da504ad060b.png)
 


### PR DESCRIPTION
Info über, dass in IOTA 1.5 es auch Transaktionen mit einem TIP geben konnte entfernt. 

Nach meinem Kenntnisstand war dies nur bei IOTA 1.0 so  --> und auch da nur für Transaktionen wo Security Level 1 zuzuordnen sind.

+ Kleine Anpassungen